### PR TITLE
feat: add blog post on the future of frontend development

### DIFF
--- a/content/posts/future-of-frontend-vibe-coding-agents.md
+++ b/content/posts/future-of-frontend-vibe-coding-agents.md
@@ -1,0 +1,103 @@
+---
+id: 3
+title: "The Future of Frontend: Vibe Coding, Agents, and What Actually Survives"
+description: "Everyone's arguing about whether AI will replace frontend developers. That's the wrong argument. Here's what's actually changing — and what isn't."
+long_description: "A philosophical and technical look at where frontend development is heading — from vibe coding to agentic workflows — and what it means for the craft, the role, and the people who actually care about building good UIs."
+createdAt: "2026-05-04T09:00:00.000Z"
+image: "https://images.unsplash.com/photo-1677442135703-1787eea5ce01?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80"
+tags:
+  - ai
+  - frontend
+  - opinion
+  - future
+category: frontend
+author:
+  name: Neel Parihar
+  twitter: neelpariharr
+  image: /images/avatar.png
+---
+
+Let me say the quiet part out loud: most of the frontend code being written in 2025 is boilerplate. Navbar, hero, card grid, form validation, loading state, error state, responsive layout. You've written it a hundred times. So has everyone else. AI can write it too, and honestly, sometimes faster than you.
+
+That's not a threat — it's just true. The question worth asking isn't *"will AI replace frontend developers?"* It's *"what is frontend development actually for?"*
+
+## Two Schools of Thought — Both Partially Right
+
+The discourse right now splits into two camps.
+
+**Camp 1: Vibe Coding is the future.** Describe what you want in plain English, iterate with a model, ship. No need to know CSS grid intimately. No need to understand the browser render pipeline. The machine handles implementation; you handle intent.
+
+**Camp 2: Agentic coding is the future.** You write specs, set constraints, define test cases — autonomous agents write the code, run the tests, fix failures, open PRs. You're an engineering director now, not an engineer.
+
+Both camps are right about the trajectory. Both are wrong about the destination.
+
+## What Vibe Coding Actually Is (And Isn't)
+
+Vibe coding — a term coined by Andrej Karpathy — describes the experience of prompting an AI, accepting its output almost wholesale, and continuing until the thing works. You're surfing intuition rather than constructing logic. The vibe is the spec.
+
+It works. Genuinely. For prototypes, internal tools, proof-of-concepts, and anything where "good enough" is actually good enough, it's faster than anything that came before it.
+
+But here's the constraint nobody talks about: **vibe coding has a ceiling, and that ceiling is your own understanding.**
+
+When the AI generates a React component that leaks a subscription in a `useEffect`, you have two options. You catch it — because you know what a stale closure looks like — and you fix the prompt. Or you don't, and you ship a memory leak wrapped in a beautiful UI.
+
+Vibe coding doesn't remove the need for understanding. It *defers* the need until something breaks. The gap between a developer who vibes their way to a working product and one who vibes their way to a maintainable product is still the same gap it always was — just harder to see until production.
+
+## What Agentic Coding Actually Changes
+
+Agentic coding is different in character from vibe coding. Instead of a conversation that produces code, you have an autonomous system that plans, executes, validates, and corrects — with or without you in the loop.
+
+This is the more structurally interesting shift. Not because it removes developers but because it *redistributes* where cognitive load lives.
+
+Today, a senior frontend developer spends roughly:
+- ~30% writing first-draft code
+- ~40% debugging, refactoring, reviewing
+- ~30% thinking about architecture, constraints, trade-offs
+
+Agentic coding mostly attacks the first category. It nibbles at the second. It barely touches the third.
+
+What that means in practice: the skill that matters stops being *"can you implement a virtual scroll list from scratch?"* and starts being *"can you spec one accurately enough that an agent implements it correctly?"*
+
+That sounds like a downgrade. It isn't. Speccing something correctly requires understanding it more deeply than implementing it, not less. Implementation lets you discover constraints as you go. A spec has to anticipate them upfront.
+
+## The Philosophical Problem: What Is a UI, Really?
+
+Here's where it gets genuinely interesting.
+
+A user interface is not just pixels arranged pleasantly. It's a **contract between a system and a human being** — a set of affordances, feedback loops, and promises about what will happen when you interact with it. Getting that contract right is a design and engineering problem simultaneously, and neither discipline has ever fully owned it.
+
+AI models are trained on existing interfaces. They reproduce patterns that already exist. That's useful for 90% of cases. But the 10% that matters most — the novel interaction pattern, the constraint-driven design decision, the moment where user research says "everyone expects X but X is wrong for this use case" — that's not in the training data.
+
+The craft of frontend has always been mediating between what's technically possible, what's visually clear, and what's actually useful for a real person in a real context. That mediation doesn't get automated. It gets harder to do badly without it being obvious.
+
+## What Actually Survives
+
+Be specific about what AI is bad at, because "nuance" is a lazy answer.
+
+**Performance instincts.** An agent will give you working code. It will rarely give you code that respects the browser's render pipeline, avoids layout thrashing, or makes the right trade-off between bundle size and cache efficiency. It doesn't feel the jank. You do.
+
+**Accessibility.** Not the low-hanging fruit — adding `alt` text and `aria-label` is table stakes and agents handle it fine. The hard accessibility work is cognitive: is this interaction model even comprehensible to someone using a screen reader? Does this focus order make sense? Does this error message tell someone what to do, not just what went wrong? That requires empathy, not syntax.
+
+**System-level thinking.** A component is easy to generate. A design system that stays coherent across 200 components built over three years by a rotating cast of developers is not. The judgment calls about when to extract an abstraction, when to allow duplication, when a component has too many props — those are architectural decisions that compound over time. Agents optimize locally. Systems require global thinking.
+
+**Debugging the non-obvious.** The bugs that take a day to find aren't syntax errors — they're emergent behaviors from the interaction of three systems that each work fine in isolation. Walking that causal chain backward is still a deeply human skill.
+
+## The Honest Career Take
+
+The frontend developer of 2028 looks less like someone who *writes* UIs and more like someone who *defines, validates, and owns* them. The implementation layer gets thinner — not absent, but thinner. The judgment layer gets thicker.
+
+That's actually closer to what the best frontend developers were always doing. The bad news is that "I can implement things correctly" becomes table stakes faster than people expect. The good news is that "I understand why things should work this way" was always the scarcer skill.
+
+There's a version of vibe coding and agentic coding that makes frontend development more accessible — lowers the barrier to building things, gets more ideas into the world faster, reduces the time spent on accidental complexity. That's genuinely good. Not just for the industry — for users, who end up with more and better software.
+
+There's also a version where the abstraction gap between what developers understand and what they ship widens until something breaks badly and nobody knows why. That's the risk. Not displacement — **hollowing out.**
+
+## Where I Land
+
+Frontend development isn't going away. The shape of it is changing faster than most people are adjusting to. The developers who treat AI as a tool they understand deeply — who know when to trust the output and when to interrogate it — will be significantly more productive than those who don't.
+
+The developers who outsource their understanding along with their implementation are building on sand. It holds fine until something shifts.
+
+Vibe coding is a legitimate workflow for the right problem. Agentic coding is going to change how teams are structured more than people expect. Neither of them changes what a good UI actually requires: someone who gives a damn about the person on the other side of the screen.
+
+That part was never in the code anyway.

--- a/content/posts/future-of-frontend-vibe-coding-agents.md
+++ b/content/posts/future-of-frontend-vibe-coding-agents.md
@@ -1,8 +1,8 @@
 ---
 id: 3
 title: "The Future of Frontend: Vibe Coding, Agents, and What Actually Survives"
-description: "Everyone's arguing about whether AI will replace frontend developers. That's the wrong argument. Here's what's actually changing — and what isn't."
-long_description: "A philosophical and technical look at where frontend development is heading — from vibe coding to agentic workflows — and what it means for the craft, the role, and the people who actually care about building good UIs."
+description: "Everyone's arguing about whether AI will replace frontend developers. That's the wrong argument. Here's what's actually changing, and what isn't."
+long_description: "A philosophical and technical look at where frontend development is heading, from vibe coding to agentic workflows, and what it means for the craft, the role, and the people who actually care about building good UIs."
 createdAt: "2026-05-04T09:00:00.000Z"
 image: "https://images.unsplash.com/photo-1677442135703-1787eea5ce01?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80"
 tags:
@@ -19,33 +19,33 @@ author:
 
 Let me say the quiet part out loud: most of the frontend code being written in 2025 is boilerplate. Navbar, hero, card grid, form validation, loading state, error state, responsive layout. You've written it a hundred times. So has everyone else. AI can write it too, and honestly, sometimes faster than you.
 
-That's not a threat — it's just true. The question worth asking isn't *"will AI replace frontend developers?"* It's *"what is frontend development actually for?"*
+That's not a threat. It's just true. The question worth asking isn't *"will AI replace frontend developers?"* It's *"what is frontend development actually for?"*
 
-## Two Schools of Thought — Both Partially Right
+## Two Schools of Thought, Both Partially Right
 
 The discourse right now splits into two camps.
 
 **Camp 1: Vibe Coding is the future.** Describe what you want in plain English, iterate with a model, ship. No need to know CSS grid intimately. No need to understand the browser render pipeline. The machine handles implementation; you handle intent.
 
-**Camp 2: Agentic coding is the future.** You write specs, set constraints, define test cases — autonomous agents write the code, run the tests, fix failures, open PRs. You're an engineering director now, not an engineer.
+**Camp 2: Agentic coding is the future.** You write specs, set constraints, define test cases. Autonomous agents write the code, run the tests, fix failures, open PRs. You're an engineering director now, not an engineer.
 
 Both camps are right about the trajectory. Both are wrong about the destination.
 
 ## What Vibe Coding Actually Is (And Isn't)
 
-Vibe coding — a term coined by Andrej Karpathy — describes the experience of prompting an AI, accepting its output almost wholesale, and continuing until the thing works. You're surfing intuition rather than constructing logic. The vibe is the spec.
+Vibe coding, a term coined by Andrej Karpathy, describes the experience of prompting an AI, accepting its output almost wholesale, and continuing until the thing works. You're surfing intuition rather than constructing logic. The vibe is the spec.
 
 It works. Genuinely. For prototypes, internal tools, proof-of-concepts, and anything where "good enough" is actually good enough, it's faster than anything that came before it.
 
 But here's the constraint nobody talks about: **vibe coding has a ceiling, and that ceiling is your own understanding.**
 
-When the AI generates a React component that leaks a subscription in a `useEffect`, you have two options. You catch it — because you know what a stale closure looks like — and you fix the prompt. Or you don't, and you ship a memory leak wrapped in a beautiful UI.
+When the AI generates a React component that leaks a subscription in a `useEffect`, you have two options. You catch it, because you know what a stale closure looks like, and you fix the prompt. Or you don't, and you ship a memory leak wrapped in a beautiful UI.
 
-Vibe coding doesn't remove the need for understanding. It *defers* the need until something breaks. The gap between a developer who vibes their way to a working product and one who vibes their way to a maintainable product is still the same gap it always was — just harder to see until production.
+Vibe coding doesn't remove the need for understanding. It *defers* the need until something breaks. The gap between a developer who vibes their way to a working product and one who vibes their way to a maintainable product is still the same gap it always was, just harder to see until production.
 
 ## What Agentic Coding Actually Changes
 
-Agentic coding is different in character from vibe coding. Instead of a conversation that produces code, you have an autonomous system that plans, executes, validates, and corrects — with or without you in the loop.
+Agentic coding is different in character from vibe coding. Instead of a conversation that produces code, you have an autonomous system that plans, executes, validates, and corrects, with or without you in the loop.
 
 This is the more structurally interesting shift. Not because it removes developers but because it *redistributes* where cognitive load lives.
 
@@ -64,9 +64,9 @@ That sounds like a downgrade. It isn't. Speccing something correctly requires un
 
 Here's where it gets genuinely interesting.
 
-A user interface is not just pixels arranged pleasantly. It's a **contract between a system and a human being** — a set of affordances, feedback loops, and promises about what will happen when you interact with it. Getting that contract right is a design and engineering problem simultaneously, and neither discipline has ever fully owned it.
+A user interface is not just pixels arranged pleasantly. It's a **contract between a system and a human being**: a set of affordances, feedback loops, and promises about what will happen when you interact with it. Getting that contract right is a design and engineering problem simultaneously, and neither discipline has ever fully owned it.
 
-AI models are trained on existing interfaces. They reproduce patterns that already exist. That's useful for 90% of cases. But the 10% that matters most — the novel interaction pattern, the constraint-driven design decision, the moment where user research says "everyone expects X but X is wrong for this use case" — that's not in the training data.
+AI models are trained on existing interfaces. They reproduce patterns that already exist. That's useful for 90% of cases. But the 10% that matters most, the novel interaction pattern, the constraint-driven design decision, the moment where user research says "everyone expects X but X is wrong for this use case", that's not in the training data.
 
 The craft of frontend has always been mediating between what's technically possible, what's visually clear, and what's actually useful for a real person in a real context. That mediation doesn't get automated. It gets harder to do badly without it being obvious.
 
@@ -76,25 +76,25 @@ Be specific about what AI is bad at, because "nuance" is a lazy answer.
 
 **Performance instincts.** An agent will give you working code. It will rarely give you code that respects the browser's render pipeline, avoids layout thrashing, or makes the right trade-off between bundle size and cache efficiency. It doesn't feel the jank. You do.
 
-**Accessibility.** Not the low-hanging fruit — adding `alt` text and `aria-label` is table stakes and agents handle it fine. The hard accessibility work is cognitive: is this interaction model even comprehensible to someone using a screen reader? Does this focus order make sense? Does this error message tell someone what to do, not just what went wrong? That requires empathy, not syntax.
+**Accessibility.** Not the low-hanging fruit. Adding `alt` text and `aria-label` is table stakes and agents handle it fine. The hard accessibility work is cognitive: is this interaction model even comprehensible to someone using a screen reader? Does this focus order make sense? Does this error message tell someone what to do, not just what went wrong? That requires empathy, not syntax.
 
-**System-level thinking.** A component is easy to generate. A design system that stays coherent across 200 components built over three years by a rotating cast of developers is not. The judgment calls about when to extract an abstraction, when to allow duplication, when a component has too many props — those are architectural decisions that compound over time. Agents optimize locally. Systems require global thinking.
+**System-level thinking.** A component is easy to generate. A design system that stays coherent across 200 components built over three years by a rotating cast of developers is not. The judgment calls about when to extract an abstraction, when to allow duplication, when a component has too many props are architectural decisions that compound over time. Agents optimize locally. Systems require global thinking.
 
-**Debugging the non-obvious.** The bugs that take a day to find aren't syntax errors — they're emergent behaviors from the interaction of three systems that each work fine in isolation. Walking that causal chain backward is still a deeply human skill.
+**Debugging the non-obvious.** The bugs that take a day to find aren't syntax errors. They're emergent behaviors from the interaction of three systems that each work fine in isolation. Walking that causal chain backward is still a deeply human skill.
 
 ## The Honest Career Take
 
-The frontend developer of 2028 looks less like someone who *writes* UIs and more like someone who *defines, validates, and owns* them. The implementation layer gets thinner — not absent, but thinner. The judgment layer gets thicker.
+The frontend developer of 2028 looks less like someone who *writes* UIs and more like someone who *defines, validates, and owns* them. The implementation layer gets thinner, not absent, but thinner. The judgment layer gets thicker.
 
 That's actually closer to what the best frontend developers were always doing. The bad news is that "I can implement things correctly" becomes table stakes faster than people expect. The good news is that "I understand why things should work this way" was always the scarcer skill.
 
-There's a version of vibe coding and agentic coding that makes frontend development more accessible — lowers the barrier to building things, gets more ideas into the world faster, reduces the time spent on accidental complexity. That's genuinely good. Not just for the industry — for users, who end up with more and better software.
+There's a version of vibe coding and agentic coding that makes frontend development more accessible: lowers the barrier to building things, gets more ideas into the world faster, reduces the time spent on accidental complexity. That's genuinely good. Not just for the industry. For users, who end up with more and better software.
 
-There's also a version where the abstraction gap between what developers understand and what they ship widens until something breaks badly and nobody knows why. That's the risk. Not displacement — **hollowing out.**
+There's also a version where the abstraction gap between what developers understand and what they ship widens until something breaks badly and nobody knows why. That's the risk. Not displacement: **hollowing out.**
 
 ## Where I Land
 
-Frontend development isn't going away. The shape of it is changing faster than most people are adjusting to. The developers who treat AI as a tool they understand deeply — who know when to trust the output and when to interrogate it — will be significantly more productive than those who don't.
+Frontend development isn't going away. The shape of it is changing faster than most people are adjusting to. The developers who treat AI as a tool they understand deeply, who know when to trust the output and when to interrogate it, will be significantly more productive than those who don't.
 
 The developers who outsource their understanding along with their implementation are building on sand. It holds fine until something shifts.
 

--- a/content/posts/future-of-frontend-vibe-coding-agents.md
+++ b/content/posts/future-of-frontend-vibe-coding-agents.md
@@ -92,8 +92,6 @@ There's a version of vibe coding and agentic coding that makes frontend developm
 
 There's also a version where the abstraction gap between what developers understand and what they ship widens until something breaks badly and nobody knows why. That's the risk. Not displacement — **hollowing out.**
 
-## Where I Land
-
 Frontend development isn't going away. The shape of it is changing faster than most people are adjusting to. The developers who treat AI as a tool they understand deeply — who know when to trust the output and when to interrogate it — will be significantly more productive than those who don't.
 
 The developers who outsource their understanding along with their implementation are building on sand. It holds fine until something shifts.

--- a/content/posts/future-of-frontend-vibe-coding-agents.md
+++ b/content/posts/future-of-frontend-vibe-coding-agents.md
@@ -92,6 +92,8 @@ There's a version of vibe coding and agentic coding that makes frontend developm
 
 There's also a version where the abstraction gap between what developers understand and what they ship widens until something breaks badly and nobody knows why. That's the risk. Not displacement — **hollowing out.**
 
+## Where I Land
+
 Frontend development isn't going away. The shape of it is changing faster than most people are adjusting to. The developers who treat AI as a tool they understand deeply — who know when to trust the output and when to interrogate it — will be significantly more productive than those who don't.
 
 The developers who outsource their understanding along with their implementation are building on sand. It holds fine until something shifts.


### PR DESCRIPTION
## Summary

- Adds a new blog post: "The Future of Frontend: Vibe Coding, Agents, and What Actually Survives"
- Covers vibe coding, agentic coding, and the philosophical question of what frontend development is actually *for*
- Takes a grounded, opinionated stance on what AI automates vs what requires human judgment — performance instincts, accessibility empathy, system-level thinking
- Matches the existing post style: direct, technically grounded, no fluff

## Test plan

- [ ] Verify post appears on the blog listing page
- [ ] Verify slug `/blog/future-of-frontend-vibe-coding-agents` resolves correctly
- [ ] Check front matter renders (title, description, tags, author) on the post page
- [ ] Confirm reading time is auto-calculated by the Nuxt Content hook

https://claude.ai/code/session_01W8AFogY5JBFSiAPFZDrfUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8AFogY5JBFSiAPFZDrfUK)_