### PR TITLE
feat: animate hero avatar — blink, hair wisps, idle float

### DIFF
--- a/components/home/HeroSection.vue
+++ b/components/home/HeroSection.vue
@@ -47,11 +47,23 @@
               <div
                 class="flex-shrink-0 w-full sm:mx-auto flex flex-1 items-center justify-center rounded-lg sm:overflow-hidden"
                 style="position:relative" id="imageAvatar">
-                <img class="rounded-md h-80" :src="$config.image" :alt="$config.name" />
+                <img class="rounded-md h-80 avatar-float" :src="$config.image" :alt="$config.name" />
+                <!-- Hair wind wisps -->
+                <svg class="hair-wisps" style="position:absolute; top:0; left:50%; transform:translateX(-50%); width:320px; height:75px; pointer-events:none;" aria-hidden="true">
+                  <path class="wisp wisp-1" d="M60,70 C80,50 100,20 140,10" stroke="#3d2b1f" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.55"/>
+                  <path class="wisp wisp-2" d="M90,72 C110,48 135,22 170,8" stroke="#3d2b1f" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.5"/>
+                  <path class="wisp wisp-3" d="M160,68 C175,44 190,20 220,6" stroke="#3d2b1f" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.45"/>
+                  <path class="wisp wisp-4" d="M200,70 C215,50 230,26 258,12" stroke="#3d2b1f" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.5"/>
+                </svg>
+                <!-- Eye patches -->
                 <div class="eye-patch" style="left: 254px; top: 118px;"> </div>
                 <div class="eye-patch" style="left: 322px; top: 118px;"></div>
+                <!-- Tracking eyes -->
                 <img class="eye" style="left: 262px; top: 116px;" src="/images/eye2.png" alt="eye1" />
                 <img class="eye" style="left: 322px; top: 116px;" src="/images/eye2.png" alt="eye2" />
+                <!-- Blinking eyelids -->
+                <div class="eyelid eyelid-left" style="left: 254px; top: 112px;"></div>
+                <div class="eyelid eyelid-right" style="left: 322px; top: 112px;"></div>
               </div>
             </div>
           </div>
@@ -74,13 +86,61 @@
   background: #ffdbb4;
 }
 
+/* Blinking eyelids */
+.eyelid {
+  position: absolute;
+  width: 22px;
+  height: 18px;
+  background: #ffdbb4;
+  transform-origin: top center;
+  transform: scaleY(0);
+  animation: blink 4s ease-in-out infinite;
+}
+
+.eyelid-right {
+  animation-delay: 0.05s;
+}
+
+@keyframes blink {
+  0%, 93%  { transform: scaleY(0); }
+  95%, 97% { transform: scaleY(1); }
+  99%, 100%{ transform: scaleY(0); }
+}
+
+/* Hair wind wisps */
+.wisp {
+  transform-origin: bottom center;
+  animation: hair-sway 3s ease-in-out infinite;
+}
+.wisp-2 { animation-delay: 0.3s; }
+.wisp-3 { animation-delay: 0.6s; }
+.wisp-4 { animation-delay: 0.9s; }
+
+@keyframes hair-sway {
+  0%, 100% { transform: translateX(0) rotate(0deg); }
+  30%      { transform: translateX(4px) rotate(1.5deg); }
+  60%      { transform: translateX(-3px) rotate(-1deg); }
+}
+
+/* Avatar idle float */
+.avatar-float {
+  animation: float-idle 3.5s ease-in-out infinite;
+}
+
+@keyframes float-idle {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-8px); }
+}
+
 @media (max-width: 1278px) {
-  .eye {
+  .eye, .eye-patch, .eyelid, .hair-wisps {
     display: none;
   }
+}
 
-  .eye-patch {
-    display: none;
+@media (prefers-reduced-motion: reduce) {
+  .eyelid, .wisp, .avatar-float {
+    animation: none;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

Three layered CSS/SVG animations added to the hero avatar in `HeroSection.vue`:

- **Blinking eyelids** — two skin-toned `div` elements sit above the existing eye-tracking layer, animating `scaleY` from 0→1→0 every 4s with a 50ms offset between left/right eye for a natural async blink
- **Hair wind wisps** — an inline `<svg>` with 4 bezier-curve paths positioned over the hair area, each strand swaying with staggered `hair-sway` keyframe delays (0s, 0.3s, 0.6s, 0.9s)
- **Idle float** — gentle `translateY(0 → -8px)` oscillation on the avatar `<img>` over 3.5s

All new elements reuse the existing `position: absolute` overlay pattern already in use for eye-patches and eyes. No new dependencies.

## Accessibility
- All three animations are disabled under `prefers-reduced-motion: reduce`
- Hair wisps and eyelids hidden at `< 1278px` (same breakpoint as existing eye elements)
- SVG has `aria-hidden="true"` and `pointer-events: none`

## Test plan
- [ ] Avatar gently floats up/down on page load
- [ ] Eyes blink approximately every 4s (watch 15–20s)
- [ ] Hair strands visibly sway at top of avatar
- [ ] Mouse cursor-tracking on eyes still works
- [ ] At viewport < 1278px: hair/eyelids hidden, float still runs
- [ ] With `prefers-reduced-motion: reduce` in DevTools: all animation stops

https://claude.ai/code/session_01W8AFogY5JBFSiAPFZDrfUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8AFogY5JBFSiAPFZDrfUK)_